### PR TITLE
Refactor fire-and-forget execution logic out of DeliveryClient

### DIFF
--- a/src/lib/ICallbackHttpClient.cs
+++ b/src/lib/ICallbackHttpClient.cs
@@ -1,0 +1,11 @@
+// Interface for an HTTP client that can run a given callback after an async call finishes.
+// This is an interface for dependency injection into DeliveryClient.
+
+namespace Promoted.Lib
+{
+    public interface ICallbackHttpClient
+    {
+        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content);
+        public void PostAsync(string requestUri, HttpContent content, Action<Task<HttpResponseMessage>> callback);
+    }
+}

--- a/src/lib/IHttpClient.cs
+++ b/src/lib/IHttpClient.cs
@@ -1,9 +1,0 @@
-// This is just for dependency injection into DeliveryClient.
-
-namespace Promoted.Lib
-{
-    public interface IHttpClient
-    {
-        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content);
-    }
-}

--- a/src/lib/OwningCallbackHttpClient.cs
+++ b/src/lib/OwningCallbackHttpClient.cs
@@ -1,0 +1,44 @@
+// In addition to implementing ICallbackHttpClient, this will:
+// 1. Take ownership of callback continuations
+// 2. Ensure that they do finish
+
+using NLog;
+using System.Collections.Concurrent;
+
+namespace Promoted.Lib
+{
+    // Disposable to ensure all pending tasks finish.
+    public class OwningCallbackHttpClient : ICallbackHttpClient, IDisposable
+    {
+        private readonly ConcurrentBag<Task> _pendingTasks = new ConcurrentBag<Task>();
+        private readonly HttpClient _httpClient = new HttpClient();
+
+        public OwningCallbackHttpClient(string apiKey, int timeoutMillis)
+        {
+            _httpClient.DefaultRequestHeaders.Add("x-api-key", apiKey);
+            _httpClient.Timeout = TimeSpan.FromMilliseconds(timeoutMillis);
+        }
+
+        public void Dispose()
+        {
+            Task.WhenAll(_pendingTasks).Wait();
+        }
+
+        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content)
+        {
+            return _httpClient.PostAsync(requestUri, content);
+        }
+
+        public void PostAsync(string requestUri, HttpContent content, Action<Task<HttpResponseMessage>> callback)
+        {
+            Task continuation = _httpClient.PostAsync(requestUri, content).ContinueWith(task =>
+            {
+                callback?.Invoke(task);
+                // Remove the completed task from our list of pending tasks.
+                _pendingTasks.TryTake(out _);
+            });
+            // Store these to ensure they get completed.
+            _pendingTasks.Add(continuation);
+        }
+    }
+}


### PR DESCRIPTION
Should simplify a lot of things in the future:
- Re-using the logic for shadow traffic
- Simplifying testing
- Simplifying batching calls in the future, if we want